### PR TITLE
Simplified checkpointing for CIQ. Aded ciq data gen scripts for paper.

### DIFF
--- a/Sweep/generate_ciq_dataset.py
+++ b/Sweep/generate_ciq_dataset.py
@@ -1,0 +1,38 @@
+"""
+Simple script to run CIQ generation code from command line.
+"""
+import argparse
+
+import numpy as np
+
+from rff import generate_ciq_data
+
+MAX_ITERATIONS = 42010 # On a 16GB GPU, we found empirically this is close to the largest feasible value (larger => more memory)
+CHECKPOINT_SIZE = 1500 # Also found empirically on 16GB GPU. Increase if a bigger card is available.
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, default=110000)
+    parser.add_argument("--lengthscale", type=float, default=1.0)
+    parser.add_argument("--outputscale", type=float, default=1.0)
+    parser.add_argument("--noise_variance", type=float, default=0.1)
+    parser.add_argument("--dimension", type=int, default=10)
+    parser.add_argument("--out", type=str, default="data.npy")
+
+    args = parser.parse_args()
+    mean = np.zeros(args.dimension)
+    covs = np.ones(args.dimension) / args.dimension
+    _iterations = int(np.log(args.n) * np.sqrt(args.n) / np.sqrt(args.noise_variance))
+    print(f"Requested iterations = {_iterations}.")
+    iterations = min(MAX_ITERATIONS, _iterations)
+    print(f"Using {iterations} iterations. Using/requested = {iterations/_iterations}")
+
+    quadrature_points = int(np.log(args.n))
+
+    lengthscale = np.array(args.lengthscale, dtype=np.float64).item()
+    outputscale = np.array(args.outputscale, dtype=np.float64).item()
+    noise_variance = np.array(args.noise_variance, dtype=np.float64).item()
+    x, y = generate_ciq_data(args.n, mean, covs, noise_variance, outputscale,
+                             lengthscale, iterations, quadrature_points, checkpoint_size=CHECKPOINT_SIZE)
+    data = np.hstack([x, y.reshape((-1, 1))])
+    np.save(args.out, data)

--- a/Sweep/generate_data.sh
+++ b/Sweep/generate_data.sh
@@ -1,0 +1,14 @@
+export OUTSCALE=1
+export NOISE_VARIANCE=0.0084
+
+
+for REP in {1..20}; do
+    for LENSCALE in {0.3,0.5,1.0,2.0,3.0}; do
+        for DIMENSION in {10,50,100}; do
+            python generate_ciq_dataset.py --n 110000 --outputscale $OUTSCALE --lengthscale $LENSCALE --noise_variance $NOISE_VARIANCE --dimension $DIMENSION --out .tmp_data/data.npy
+            echo "LENSCALE=$LENSCALE, DIMENSION=$DIMENSION, REP=$REP"
+            aws s3 cp .tmp_data/data.npy s3://nicholas92457/gaussian-process-array-datasets/ciq_synthetic_var0008/DIM{$DIMENSION}_LENSCALE{$LENSCALE}_{$REP}/data.npy
+            rm .tmp_data/data.npy
+        done
+    done
+done


### PR DESCRIPTION
Included are the scripts I have been using to generate data for the paper. I simplified the kernel checkpointing stuff, because Lanczos iterations and kernel checkpoint size contribute to memory. It's now just a kwarg of the generation function, and the highest value I could use is hard coded into the experiment script.